### PR TITLE
Update Dockerfile to use trinitytechnology/ebrick as the base image

### DIFF
--- a/internal/templates/templates/Dockerfile.tmpl
+++ b/internal/templates/templates/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Start from the official Golang image to build the binary.
-FROM golang:1.22.5-alpine3.20 AS builder
+FROM trinitytechnology/ebrick AS builder
 
 # Set the Current Working Directory inside the container.
 WORKDIR /app
@@ -11,7 +11,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o app ./cmd
+RUN ebrick build
 
 # Start a new stage from scratch for a smaller final image.
 FROM alpine:3.20
@@ -20,7 +20,6 @@ WORKDIR /app
 
 # Copy the pre-built binary file from the previous stage.
 COPY --from=builder /app/app .
-
-RUN ls -l
+COPY --from=builder /app/application.yaml .
 
 CMD ["/app/app"]

--- a/internal/templates/templates/Dockerfile.tmpl
+++ b/internal/templates/templates/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Start from the official Golang image to build the binary.
-FROM trinitytechnology/ebrick AS builder
+FROM trinitytechnology/ebrick:latest AS builder
 
 # Set the Current Working Directory inside the container.
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the Dockerfile to use `trinitytechnology/ebrick` as the base image instead of `golang:1.22.5-alpine3.20`. This change ensures that the application is built using the desired base image and improves the overall consistency of the project.