### PR TITLE
Refactor command-line flags in main.go

### DIFF
--- a/cmd/ebrick/main.go
+++ b/cmd/ebrick/main.go
@@ -119,8 +119,7 @@ func buildApp() *cobra.Command {
 	}
 
 	// Add ldflags as a command-line flag
-	cmd.Flags().StringVar(&ldflags, "ldflags", "", "Flags to pass to go build, such as -ldflags \"-X main.version=1234\"")
-	cmd.Flags().StringVar(&output, "o", "app", "Output file name")
-
+	cmd.Flags().StringVarP(&ldflags, "ldflags", "l", "", "Flags to pass to go build, such as -ldflags \"-X main.version=1234\"")
+	cmd.Flags().StringVarP(&output, "output", "o", "app", "Output file name")
 	return cmd
 }


### PR DESCRIPTION
This pull request refactors the command-line flags in the `main.go` file. The `ldflags` flag has been changed to use the shorthand `-l` and the `output` flag has been changed to use the shorthand `-o`. This improves the readability and usability of the command-line interface.