### PR TITLE
Update framework version to v0.4.0

### DIFF
--- a/cmd/ebrick/main.go
+++ b/cmd/ebrick/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var version = "development"
-var frameworkVersion = "v0.3.5"
+var frameworkVersion = "v0.4.0"
 
 //go:embed banner.txt
 var banner string


### PR DESCRIPTION
This pull request includes a small change to the `cmd/ebrick/main.go` file. The change updates the `frameworkVersion` variable to a new version.

* [`cmd/ebrick/main.go`](diffhunk://#diff-91a4ffb87b0771fce1a1330e44a73ba5f90e02e17493c54f8cedc1123327dd19L15-R15): Updated `frameworkVersion` variable from "v0.3.5" to "v0.4.0".